### PR TITLE
Fixed PasswordEncoder, JwtEncoder bean not loading

### DIFF
--- a/src/main/java/io/example/configuration/SecurityConfig.java
+++ b/src/main/java/io/example/configuration/SecurityConfig.java
@@ -40,6 +40,7 @@ import org.springframework.web.filter.CorsFilter;
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true, jsr250Enabled = true, prePostEnabled = true)
 @RequiredArgsConstructor
+@Configuration
 public class SecurityConfig {
 
   private final UserRepo userRepo;


### PR DESCRIPTION
Spring @Configuration annotation is part of the spring core framework. Spring Configuration annotation indicates that the class has @Bean definition methods. So Spring container can process the class and generate Spring Beans to be used in the application. Without it the Beans wont get loaded neither they'll be able to Autowire in other classes.